### PR TITLE
Update URL for choosealicense

### DIFF
--- a/PackagingAndRepos.ipynb
+++ b/PackagingAndRepos.ipynb
@@ -392,7 +392,7 @@
    "source": [
     "A bet you didn't expect to be reading legalese today... but it turns out this is important.  If you do not explicitly license your code, in most countries (including the US and EU) it is technically **illegal** for anyone to use your code for any purpose other than just looking at it.\n",
     "\n",
-    "(Un?)Fortunately, there are a lot of possible open source licenses out there.  Assuming you want an open license, the best resources is to use the [\"Choose a License\" website](http://choosealicense.org). Have a look over the options there and decide which you think is appropriate for your code."
+    "(Un?)Fortunately, there are a lot of possible open source licenses out there.  Assuming you want an open license, the best resources is to use the [\"Choose a License\" website](http://choosealicense.com). Have a look over the options there and decide which you think is appropriate for your code."
    ]
   },
   {


### PR DESCRIPTION
`.org` works but redirects to `.com` anyway, as mentioned by @arfon